### PR TITLE
Add more configuration options

### DIFF
--- a/FreeTAKServer-UI/app/__init__.py
+++ b/FreeTAKServer-UI/app/__init__.py
@@ -6,6 +6,7 @@ go to line 77+ for configuring the FTS UI
 """
 
 from flask import Flask, url_for
+from flask_cors import CORS
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy_utils.functions import database_exists
@@ -76,6 +77,12 @@ def apply_themes(app):
 def create_app(config, selenium=False):
     app = Flask(__name__, static_folder='base/static')
     app.config.from_object(config)
+    
+    # apply cors only for api route and webmap route
+    api_uri = f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}"
+    webmap_uri = f"{app.config['WEBMAPPROTOCOL']}://{app.config['WEBMAPIP']}:{app.config['WEBMAPPORT']}"
+    CORS(app, origins=[api_uri, webmap_uri])
+    
     #if database_exists(app.config['SQLALCHEMY_DATABASE_URI']) == False:
     #    raise Exception("Database does not exist, check your DataBase path and ensure that you've started FTS")
     # UI configuration

--- a/FreeTAKServer-UI/app/base/routes.py
+++ b/FreeTAKServer-UI/app/base/routes.py
@@ -39,7 +39,7 @@ def login():
         password = request.form['password']
 
         # Locate user
-        user = requests.get(f"http://{app.config['IP']}:{app.config['PORT']}/AuthenticateUser", params={"username": username, "password": password}, headers={"Authorization": f"{app.config['APIKEY']}"})
+        user = requests.get(f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}/AuthenticateUser", params={"username": username, "password": password}, headers={"Authorization": f"{app.config['APIKEY']}"})
         try:
             user = user.json()
         except:

--- a/FreeTAKServer-UI/app/base/templates/login/login.html
+++ b/FreeTAKServer-UI/app/base/templates/login/login.html
@@ -23,8 +23,7 @@
                         <span class="text-danger">{{ msg | safe }}</span>
                       {% else %}
                       <span style="font-size: 14px;">
-                        Welcome to FTS administration, please insert you credential
-                       
+                        Welcome to FTS administration, please insert your credentials
                       </span>
                       {% endif %}  
                   </h6>

--- a/FreeTAKServer-UI/app/home/routes.py
+++ b/FreeTAKServer-UI/app/home/routes.py
@@ -28,7 +28,7 @@ def index():
        return redirect(url_for('base_blueprint.login'))
 
     return render_template('index.html', segment='index',
-    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], ip=app.config['IP'],
+    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], protocol=app.config['PROTOCOL'], ip=app.config['IP'],
     userinterval=app.config['USERINTERVAL'],serverhealthinterval=app.config['SERVERHEALTHINTERVAL'], sysstatusinterval=app.config['SYSSTATUSINTERVAL']
     )
 
@@ -39,13 +39,13 @@ def missionApi():
     
     headers = {'Authorization': app.config['APIKEY']}
 
-    json_data = requests.get('http://' + app.config['IP'] + ':' + app.config['PORT'] + '/DataPackageTable', headers= headers).json()
+    json_data = requests.get(f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}/DataPackageTable", headers= headers).json()
     
-    mission_json_data = requests.get('http://' + app.config['IP'] + ':' + app.config['PORT'] + '/MissionTable', headers= headers).json()
+    mission_json_data = requests.get(f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}/MissionTable", headers= headers).json()
 
-    excheck_json_data = requests.get('http://' + app.config['IP'] + ':' + app.config['PORT'] + '/ExCheckTable', headers= headers).json()
+    excheck_json_data = requests.get(f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}/ExCheckTable", headers= headers).json()
 
-    outgoing_federation_json_data = requests.get('http://' + app.config['IP'] + ':' + app.config['PORT'] + '/FederationTable', headers= headers).json()
+    outgoing_federation_json_data = requests.get(f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}/FederationTable", headers= headers).json()
     
    
     return render_template('mission.html', json_data = json_data['json_list'], 
@@ -53,7 +53,7 @@ def missionApi():
     excheck_json_data = excheck_json_data['ExCheck']['Templates'],
     outgoing_federation_json_data = outgoing_federation_json_data['federations'],
     segment = "mission",
-    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], ip=app.config['IP'],
+    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], protocol=app.config['PROTOCOL'], ip=app.config['IP'],
     datapackagesizelimit=app.config['DATAPACKAGESIZELIMIT']
     
      )
@@ -66,41 +66,42 @@ def missionApi():
 @login_required
 def connectApi():
     headers = {'Authorization': app.config['APIKEY']}
-    json_data = requests.get('http://' + app.config['IP'] + ':' + app.config['PORT'] + '/ManageEmergency/getEmergency', headers= headers)
+    json_data = requests.get(f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}/ManageEmergency/getEmergency", headers= headers)
     json_data = json_data.json()
     
     return render_template('connect.html', json_data = json_data['json_list'], segment="connect",
-    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], ip=app.config['IP'])     
+    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], protocol=app.config['PROTOCOL'], ip=app.config['IP'])     
 
 
 @blueprint.route('/configure')
 @login_required
 def configureApi():
     headers = {'Authorization': app.config['APIKEY']}
-    outgoing_federation_json_data = requests.get('http://' + app.config['IP'] + ':' + app.config['PORT'] + '/FederationTable', headers= headers).json()
+    outgoing_federation_json_data = requests.get(f"{app.config['PROTOCOL']}://{app.config['IP']}:{app.config['PORT']}/FederationTable", headers= headers).json()
 
     return render_template('configure.html', segment="configure", 
     outgoing_federation_json_data = outgoing_federation_json_data['federations'],
-    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], ip=app.config['IP'])
+    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], protocol=app.config['PROTOCOL'], ip=app.config['IP'])
 
 @blueprint.route('/users')
 @login_required
 def usersApi():
     return render_template('users.html', segment="users", 
-    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], ip=app.config['IP'])     
+    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], protocol=app.config['PROTOCOL'], ip=app.config['IP'])     
       
 @blueprint.route('/about')
 @login_required
 def aboutApi():
     return render_template('about.html', segment="about", uiversion=app.config['UIVERSION'],
-    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], ip=app.config['IP'])     
+    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'], protocol=app.config['PROTOCOL'], ip=app.config['IP'])     
 
 @blueprint.route('/webmap')
 @login_required
 def webmapApi():
     return render_template('webmap.html', segment="webmap", uiversion=app.config['UIVERSION'],
-                           websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'], port=app.config['PORT'],
-                           ip=app.config['IP'], webmapip=app.config['WEBMAPIP'], webmapport=app.config["WEBMAPPORT"])
+    websocketkey=app.config['WEBSOCKETKEY'], apikey=app.config['APIKEY'],
+    ip=app.config['IP'], protocol=app.config['PROTOCOL'], port=app.config['PORT'],
+    webmapip=app.config['WEBMAPIP'], webmapport=app.config['WEBMAPPORT'], webmapprotocol=app.config['WEBMAPPROTOCOL'])
 
 @blueprint.route('/page-user', methods=['GET', 'POST'])
 @login_required

--- a/FreeTAKServer-UI/app/home/templates/about.html
+++ b/FreeTAKServer-UI/app/home/templates/about.html
@@ -120,7 +120,7 @@
      document.getElementById("ui-ip").innerText = self.location.host ;
 
 	 async function establishConnection() {
-		var socket = io.connect(`http://{{ip}}:{{port}}`);
+		var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 		getConnectInfo(socket);
 		let isAuth = await authenticate(socket);
 
@@ -194,5 +194,3 @@
 </script>
 
 {% endblock javascripts %}
-
-

--- a/FreeTAKServer-UI/app/home/templates/configure.html
+++ b/FreeTAKServer-UI/app/home/templates/configure.html
@@ -296,7 +296,7 @@
 <script>
 
 
-var socket = io.connect(`http://{{ip}}:{{port}}`);
+var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 
 var orig_tcp_cot_status;
 var orig_ssl_cot_status;
@@ -518,7 +518,7 @@ function addOF() {
 		} 
 
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/FederationTable", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/FederationTable", {
 			method: "POST",
 			headers: headers,
 			body: JSON.stringify(obj),

--- a/FreeTAKServer-UI/app/home/templates/connect.html
+++ b/FreeTAKServer-UI/app/home/templates/connect.html
@@ -330,7 +330,7 @@
 		};
 
 		headers = { "Content-Type": "application/json", Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/ManageGeoObject/postGeoObject", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/ManageGeoObject/postGeoObject", {
 			method: "post",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -372,7 +372,7 @@
 		};
 
 		headers = { "Content-Type": "application/json", Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/ManageChat/postChatToAll", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/ManageChat/postChatToAll", {
 			method: "post",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -411,7 +411,7 @@
 		};
 
 		headers = { "Content-Type": "application/json", Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/ManageEmergency/postEmergency", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/ManageEmergency/postEmergency", {
 			method: "post",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -456,7 +456,7 @@
 		};
 
 		headers = { "Content-Type": "application/json", Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/ManagePresence/postPresence", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/ManagePresence/postPresence", {
 			method: "post",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -515,7 +515,7 @@
 		};
 
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/ManageEmergency/deleteEmergency", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/ManageEmergency/deleteEmergency", {
 			method: "DELETE",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -530,7 +530,7 @@
 
 	async function establishConnection() {
 		console.log("Make connection");
-		var socket = io.connect(`http://{{ip}}:{{port}}`);
+		var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 
 		console.log("Emit event authenticate...");
 

--- a/FreeTAKServer-UI/app/home/templates/index.html
+++ b/FreeTAKServer-UI/app/home/templates/index.html
@@ -386,7 +386,7 @@
 		// this gets current server data
 		async function establishConnection() {
 			console.log("Make connection");
-			var socket = io.connect(`http://{{ip}}:{{port}}`);
+			var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 			// connect_timeout
 			socket.on('connect_error', function() {
 				   console.log("Sorry, there seems to be an issue with the connection!");
@@ -759,4 +759,3 @@
 
 	{% endblock javascripts %}
 </div>
-

--- a/FreeTAKServer-UI/app/home/templates/mission.html
+++ b/FreeTAKServer-UI/app/home/templates/mission.html
@@ -408,7 +408,7 @@
 
 <script>
 
-var socket = io.connect(`http://{{ip}}:{{port}}`);
+var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 
 var tcpip;
 var tcpport;
@@ -558,7 +558,7 @@ const authenticate = (socket) => {
 
 	function downloadFile(param, name) {
 		
-		let url = `http://${tcpip}:${tcpport}/Marti/api/sync/metadata/${param}/tool`;
+		let url = `${protocol}://${tcpip}:${tcpport}/Marti/api/sync/metadata/${param}/tool`;
 		headers = { Authorization: "{{apikey | safe}}", Connection: "Keep-Alive" };
 
 		
@@ -647,7 +647,7 @@ const authenticate = (socket) => {
 
 		headers = { Authorization: "{{apikey | safe}}", Connection: "Keep-Alive" };
 
-		fetch(`http://{{ip}}:{{port}}/DataPackageTable?filename=${file.name}&creator={{current_user.name}}`, {
+		fetch(`{{protocol}}://{{ip}}:{{port}}/DataPackageTable?filename=${file.name}&creator={{current_user.name}}`, {
 			method: "POST",
 			headers: headers,
 			body: formData,
@@ -703,7 +703,7 @@ const authenticate = (socket) => {
 
 		headers = { Authorization: "{{apikey | safe}}", Connection: "Keep-Alive" };
 		
-		fetch(`http://{{ip}}:{{port}}/ExCheckTable`, {
+		fetch(`{{protocol}}://{{ip}}:{{port}}/ExCheckTable`, {
 			method: "POST",
 			headers: headers,
 			body: inputExcheck.files[0],
@@ -770,7 +770,7 @@ const authenticate = (socket) => {
 	function deleteDataPackage() {
 		
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/DataPackageTable", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/DataPackageTable", {
 			method: "DELETE",
 			headers: headers,
 			body: JSON.stringify({
@@ -796,7 +796,7 @@ const authenticate = (socket) => {
 
 		
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/ExCheckTable", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/ExCheckTable", {
 			method: "DELETE",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -815,7 +815,7 @@ const authenticate = (socket) => {
 		}
 
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/FederationTable", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/FederationTable", {
 			method: "DELETE",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -842,7 +842,7 @@ const authenticate = (socket) => {
 		} 
 
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/FederationTable", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/FederationTable", {
 			method: "POST",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -869,7 +869,7 @@ const authenticate = (socket) => {
 		} 
 
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/FederationTable", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/FederationTable", {
 			method: "PUT",
 			headers: headers,
 			body: JSON.stringify(obj),
@@ -907,7 +907,7 @@ const authenticate = (socket) => {
 		};
 		
 		headers = { Authorization: "{{apikey | safe}}" };
-		fetch("http://{{ip}}:{{port}}/DataPackageTable", {
+		fetch("{{protocol}}://{{ip}}:{{port}}/DataPackageTable", {
 			method: "PUT",
 			headers: headers,
 			body: JSON.stringify(obj),

--- a/FreeTAKServer-UI/app/home/templates/users.html
+++ b/FreeTAKServer-UI/app/home/templates/users.html
@@ -163,7 +163,7 @@
 	// this gets current server data
 	async function establishConnection() {
 		console.log("Make connection");
-		var socket = io.connect(`http://{{ip}}:{{port}}`);
+		var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 
 		console.log("Emit event authenticate...");
 
@@ -354,7 +354,7 @@
 	}
 
 	const removeUsers = async () => {
-		var socket = io.connect(`http://{{ip}}:{{port}}`);
+		var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 
 		let obj = {
 			systemUsers: uArr,
@@ -404,7 +404,7 @@
 			],
 		};
 
-		var socket = io.connect(`http://{{ip}}:{{port}}`);
+		var socket = io.connect(`{{protocol}}://{{ip}}:{{port}}`);
 
 		console.log("Emit event authenticate...");
 

--- a/FreeTAKServer-UI/app/home/templates/webmap.html
+++ b/FreeTAKServer-UI/app/home/templates/webmap.html
@@ -17,7 +17,7 @@
 <!-- ======= Header tools ======= -->
 <body>
     <div id="content">
-        <iframe src= "http://{{ webmapip }}:{{ webmapport }}/tak-map" title="webmap" width="100%" height="100%"></iframe>
+        <iframe src= "{{ webmapprotocol }}://{{ webmapip }}:{{ webmapport }}/tak-map" title="webmap" width="100%" height="100%"></iframe>
     </div>
 </body>
 {% endblock content %}

--- a/FreeTAKServer-UI/config.py
+++ b/FreeTAKServer-UI/config.py
@@ -28,22 +28,28 @@ class Config(object):
     # this IP will be used to connect with the FTS API
     IP = '127.0.0.1'
 
-    # Port the  UI uses to communicate with the API
+    # Port the UI uses to communicate with the API
     PORT = '19023'
+
+    # Protocol the UI uses to communicate with the API
+    PROTOCOL = 'http'
 
     # the public IP your server is exposing
     APPIP = '127.0.0.1'
 
     # webmap IP
-    WEBMAPIP = "127.0.0.1"
+    WEBMAPIP = '127.0.0.1'
 
     # webmap port
     WEBMAPPORT = 8000
 
+    # webmap protocol
+    WEBMAPPROTOCOL = 'http'
+
     # this port will be used to listen
     APPPort = 5000
 
-    # the webSocket  key used by the UI to communicate with FTS.
+    # the webSocket key used by the UI to communicate with FTS.
     WEBSOCKETKEY = 'YourWebsocketKey'
 
     # the API key used by the UI to comunicate with FTS. generate a new system user and then set it

--- a/FreeTAKServer-UI/run.py
+++ b/FreeTAKServer-UI/run.py
@@ -66,11 +66,28 @@ app = create_app( app_config )
         '-i', '--ip_address', type=str, help='ip address of the target host'
         , required=False)
     parser.add_argument(
+        '-ap', '--api_port', type=int, help='Port of the target host'
+        , required=False)
+    parser.add_argument(
+        '-ac', '--api_protocol', type=str, help='Protocol of the target host'
+        , required=False)
+    parser.add_argument(
         '-k', '--key', type=str, help='Web Socket key for the UI'
         , required=False)
     parser.add_argument(
         '-p', '--port', type=int, help='Port for the Web UI HTTP'
         , required=False)
+    parser.add_argument(
+        '-c', '--protocol', type=str, help='Protocol serving the Web UI HTTP'
+        , required=False)
+    parser.add_argument(
+        '-wi', '--webmap_ip', type=str, help='ip address of the webmap host'
+        , required=False)
+    parser.add_argument(
+        '-wc', '--webmap_protocol', type=str, help='protocol of the webmap host'
+        , required=False)
+    parser.add_argument(
+        '-wp', '--webmap_port', type=int, help='port of the webmap host'
     parser.add_argument(
         '-d','--debug', default=False, dest='debug',action='store_true'
         ,help='Enable Debug mode')
@@ -85,6 +102,21 @@ app = create_app( app_config )
     if arguments.ip_address:
         print("IP Address override: " + str(arguments.ip_address))
         app.config['IP'] = arguments.ip_address
+    if arguments.api_port:
+        print("API Port override: " + str(arguments.api_port))
+        app.config['PORT'] = arguments.api_port
+    if arguments.api_protocol:
+        print("API Protocol override: " + str(arguments.api_protocol))
+        app.config['PROTOCOL'] = arguments.api_protocol
+    if arguments.webmap_ip:
+        print("Web Map IP override: " + str(arguments.webmap_ip))
+        app.config['WEBMAPIP'] = arguments.webmap_ip
+    if arguments.webmap_protocol:
+        print("Web Map Protocol override: " + str(arguments.webmap_protocol))
+        app.config['WEBMAPPROTOCOL'] = arguments.webmap_protocol
+    if arguments.webmap_port:
+        print("Web Map Port override: " + str(arguments.webmap_port))
+        app.config['WEBMAPPORT'] = arguments.webmap_port
     if arguments.key:
         print("Web Socket Key override: " + str(arguments.key))
         app.config['WEBSOCKETKEY'] = arguments.key

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ flask_login
 flask_migrate
 flask_wtf
 flask_sqlalchemy
+flask_cors
 email_validator
 gunicorn


### PR DESCRIPTION
## Overview
This PR improves configuration options to allow the FreeTAKServer UI to run with more varied configurations, such as behind a reverse proxy, or with the API and webmap on separate domains.

The FreeTAKServer UI is expected to run on port 5000, but has hardcoded calls using the http protocol, which can get blocked for mixed content if the FTS UI is hosted via https. In addition, this PR allows for connecting to FTS API or webmaps hosted via https, as well.

## Changes
- Adds additional `PROTOCOL` config variable for the protocol needed for the API endpoint
- Adds additional `WEBMAPPROTOCOL` config variable for the protocol needed for the webmap endpoint
- Whitelists CORS for API endpoint and webmap endpoint

## Related PRs
- Linked PR for [FreeTAKServer-User-Docs](https://github.com/FreeTAKTeam/FreeTAKServer-User-Docs/pull/10) for these new variables 

Please don't hesitate to give feedback or commentary on these changes! My python is a bit rusty, so I'm not sure if there's anything that I missed. Thank you!