### PR TITLE
Fixed README.md copy in .Dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 # .dockerignore
 *.md
+!README.md
 .gitignore
 .github


### PR DESCRIPTION
Hi Hi, 

When excluding all `*.md` file in the [.dockerignore](.Dockerignore) it sadly broke the poetry dependency installation as the needed [README.md](README.md) is not copied anymore during a `docker build`:

```
docker build -t freetakserver-ui:latest .

...

 > [6/6] RUN pip install .:                                                                                                                                            
0.999 Defaulting to user installation because normal site-packages is not writeable                                                                                    
1.072 Processing /home/freetak                                                                                                                                         
1.074   Installing build dependencies: started                                                                                                                         
20.53   Installing build dependencies: finished with status 'done'                                                                                                     
20.53   Getting requirements to build wheel: started
20.76   Getting requirements to build wheel: finished with status 'done'
20.76   Preparing metadata (pyproject.toml): started
21.11   Preparing metadata (pyproject.toml): finished with status 'error'
21.11   error: subprocess-exited-with-error
21.11   
21.11   × Preparing metadata (pyproject.toml) did not run successfully.
21.11   │ exit code: 1
21.11   ╰─> [24 lines of output]
21.11       Traceback (most recent call last):
21.11         File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
21.11           main()
21.11         File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
21.11           json_out['return_val'] = hook(**hook_input['kwargs'])
21.11                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21.11         File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
21.11           return hook(metadata_directory, config_settings)
21.11                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21.11         File "/tmp/pip-build-env-13tfojt_/overlay/lib/python3.11/site-packages/poetry/core/masonry/api.py", line 43, in prepare_metadata_for_build_wheel
21.11           builder = WheelBuilder(poetry)
21.11                     ^^^^^^^^^^^^^^^^^^^^
21.11         File "/tmp/pip-build-env-13tfojt_/overlay/lib/python3.11/site-packages/poetry/core/masonry/builders/wheel.py", line 62, in __init__
21.11           super().__init__(poetry, executable=executable)
21.11         File "/tmp/pip-build-env-13tfojt_/overlay/lib/python3.11/site-packages/poetry/core/masonry/builders/builder.py", line 55, in __init__
21.11           self._meta = Metadata.from_package(self._package)
21.11                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21.11         File "/tmp/pip-build-env-13tfojt_/overlay/lib/python3.11/site-packages/poetry/core/masonry/metadata.py", line 58, in from_package
21.11           with readme.open(encoding="utf-8") as f:
21.11                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21.11         File "/usr/local/lib/python3.11/pathlib.py", line 1044, in open
21.11           return io.open(self, mode, buffering, encoding, errors, newline)
21.11                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21.11       FileNotFoundError: [Errno 2] No such file or directory: '/home/freetak/README.md'
21.11       [end of output]
21.11   
21.11   note: This error originates from a subprocess, and is likely not a problem with pip.
21.11 error: metadata-generation-failed
21.11 
21.11 × Encountered error while generating package metadata.
21.11 ╰─> See above for output.
21.11 
21.11 note: This is an issue with the package mentioned above, not pip.
21.11 hint: See above for details.
```

It can be fixed by ignoring all `*.md` files unless it's the needed `README.md` file :vulcan_salute: 